### PR TITLE
Update etherpad-lite.rules

### DIFF
--- a/etherpad-lite.rules
+++ b/etherpad-lite.rules
@@ -1,13 +1,6 @@
-# etherpad-lite whitelist rules
-BasicRule  wl:11 "mz:$URL:/socket.io/|BODY";
-BasicRule  wl:1101 "mz:$URL:/jserror|$BODY_VAR:errorinfo";
-BasicRule  wl:1015 "mz:$URL:/jserror|$BODY_VAR:errorinfo";
-BasicRule  wl:1013 "mz:$URL:/jserror|$BODY_VAR:errorinfo";
-BasicRule  wl:1011 "mz:$URL:/jserror|$BODY_VAR:errorinfo";
-BasicRule  wl:1010 "mz:$URL:/jserror|$BODY_VAR:errorinfo";
-BasicRule  wl:1008 "mz:$URL:/jserror|$BODY_VAR:errorinfo";
-BasicRule  wl:1001 "mz:$URL:/jserror|$BODY_VAR:errorinfo";
+# Etherpad: Really real-time collaborative document editing http://etherpad.org
+BasicRule  wl:1101,1015,1013,1011,1010,1008,1001 "mz:$URL:/jserror|$BODY_VAR:errorinfo";
 BasicRule  wl:2 "mz:$URL_X:^/p/.*/import$|BODY";
-BasicRule  wl:1315 "mz:$HEADERS_VAR:cookie";
 BasicRule  wl:1311 "mz:$URL_X:^/p/.*]$|URL";
-#BasicRule  wl:1311 "mz:URL";
+BasicRule  wl:1007 "mz:URL";
+BasicRule  wl:1315 "mz:$HEADERS_VAR:cookie";

--- a/etherpad-lite.rules
+++ b/etherpad-lite.rules
@@ -4,3 +4,4 @@ BasicRule  wl:2 "mz:$URL_X:^/p/.*/import$|BODY";
 BasicRule  wl:1311 "mz:$URL_X:^/p/.*]$|URL";
 BasicRule  wl:1007 "mz:URL";
 BasicRule  wl:1315 "mz:$HEADERS_VAR:cookie";
+BasicRule  wl:11 "mz:$URL:/socket.io/|BODY";


### PR DESCRIPTION
Removing id 11 will cause error with etherpad.
TypeError: pad.collabClient is null in /javascripts/lib/ep_etherpad-lite/static/js/pad.js?callback=require.define at line 266