### PR TITLE
Added more plugin-related WordPress rules.

### DIFF
--- a/wordpress.rules
+++ b/wordpress.rules
@@ -136,3 +136,17 @@ BasicRule wl:1000 "mz:$BODY_VAR:query_args[update_post_term_cache]|NAME";
 BasicRule wl:1000 "mz:$BODY_VAR:query_args[update_post_meta_cache]|NAME";
 #UpdraftPlus
 BasicRule wl:1000 "mz:$URL:/wp-content/plugins/updraftplus/includes/select2/select2.min.css|URL";
+BasicRule wl:1000 "mz:$URL:/wp-content/plugins/updraftplus/includes/select2/select2.min.js|URL";
+#WP plugin updates
+BasicRule wl:1315 "mz:$ARGS_VAR:query|$URL:/wp-json/jetpack/v4/jitm";
+#Jetpack Google Fonts
+BasicRule wl:1001 "mz:$URL_X:^/wp-content/plugins/jetpack/css/.*|URL";
+#WooCommerce
+BasicRule wl:1000 "mz:$URL:/wp-content/plugins/woocommerce/assets/js/select2/select2.full.min.js|URL";
+BasicRule wl:1000 "mz:$URL:/wp-content/plugins/woocommerce/assets/js/selectWoo/selectWoo.full.min.js|URL";
+BasicRule wl:1000 "mz:$URL:/wp-content/plugins/woocommerce/assets/js/stupidtable/stupidtable.min.js|URL";
+#WPML
+BasicRule wl:1000 "mz:$URL:/wp-content/plugins/sitepress-multilingual-cms/lib/select2/select2.min.js|URL";
+#Yoast SEO
+BasicRule wl:1000 "mz:$URL:/wp-content/plugins/wordpress-seo/js/dist/select2/select2.full.min.js|URL";
+BasicRule wl:1000 "mz:$URL:/wp-content/plugins/wordpress-seo/css/dist/select2/select2.min.css|URL";


### PR DESCRIPTION
The why and what is in #32 

Some more plugin-related rules have been added here, especially for the **select2** library used in the following plugins:

- UpdraftPlus
- WooCommerce
- WPML
- Yoast SEO

I'm not sure of any other plugins which use this library, but those should have exceptions added here, also.  I hope this helps some other people.  Thanks to @chepurko for most of the rules in this commit.  They're pulled from [this repository](https://github.com/daxio/k8s-lemp/tree/master/wp/nginx/global).  The **selectWoo** script in WooCommerce and **Yoast SEO** entries are new.